### PR TITLE
Use alpine-3.4 and reload Caddy instead of restart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nimmis/alpine:3.3
+FROM nimmis/alpine:3.4
 MAINTAINER BlackGlory <woshenmedoubuzhidao@blackglory.me>
 
 RUN apk update && apk upgrade && \

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Then to run it:
 $ docker run -v /var/run/docker.sock:/tmp/docker.sock:ro -v /data/.caddy:/root/.caddy --name caddy-proxy -p 80:80 -p 443:443 -e CADDY_OPTIONS="--email youremail@example.com" -d blackglory/caddy-proxy:0.2.0
 ```
 
-When you launch new (or stop) containers caddy-proxy will restart to make the new containers available.
+When you launch new (or stop) containers caddy-proxy will reload its configuration to make the new containers available.

--- a/etc/caddy-proxy/caddy.tmpl
+++ b/etc/caddy-proxy/caddy.tmpl
@@ -9,18 +9,20 @@
     {{ if eq $addrLen 1 }}
       {{ with $address := index $value.Addresses 0 }}
       proxy / {{ $address.IP }}:{{ $address.Port }} {
-        proxy_header Host {host}
-        proxy_header X-Real-IP {remote}
-        proxy_header X-Forwarded-Proto {scheme}
+        header_upstream Host {host}
+        header_upstream X-Real-IP {remote}
+        header_upstream X-Forwarded-For {remote}
+        header_upstream X-Forwarded-Proto {scheme}
       }
       {{ end }}
     {{ else if $value.Env.VIRTUAL_PORT }}
       {{ range $i, $address := $value.Addresses }}
         {{ if eq $address.Port $value.Env.VIRTUAL_PORT }}
         proxy / {{ $address.IP }}:{{ $address.Port }} {
-          proxy_header Host {host}
-          proxy_header X-Real-IP {remote}
-          proxy_header X-Forwarded-Proto {scheme}
+          header_upstream Host {host}
+          header_upstream X-Real-IP {remote}
+          header_upstream X-Forwarded-For {remote}
+          header_upstream X-Forwarded-Proto {scheme}
         }
         {{ end }}
       {{ end }}
@@ -28,9 +30,10 @@
       {{ range $i, $address := $value.Addresses }}
         {{ if eq $address.Port "80" }}
         proxy / {{ $address.IP }}:{{ $address.Port }} {
-          proxy_header Host {host}
-          proxy_header X-Real-IP {remote}
-          proxy_header X-Forwarded-Proto {scheme}
+          header_upstream Host {host}
+          header_upstream X-Real-IP {remote}
+          header_upstream X-Forwarded-For {remote}
+          header_upstream X-Forwarded-Proto {scheme}
         }
         {{ end }}
       {{ end }}

--- a/etc/supervisor.d/caddy.conf
+++ b/etc/supervisor.d/caddy.conf
@@ -1,2 +1,2 @@
 [program:caddy]
-command=caddy --conf /etc/Caddyfile %(ENV_CADDY_OPTIONS)s
+command=caddy -conf /etc/Caddyfile %(ENV_CADDY_OPTIONS)s

--- a/etc/supervisor.d/docker-gen.conf
+++ b/etc/supervisor.d/docker-gen.conf
@@ -1,2 +1,2 @@
 [program:docker-gen]
-command=docker-gen -notify "supervisorctl restart caddy" -watch /etc/caddy-proxy/caddy.tmpl /etc/Caddyfile
+command=docker-gen -notify "supervisorctl signal USR1 caddy" -watch /etc/caddy-proxy/caddy.tmpl /etc/Caddyfile


### PR DESCRIPTION
The base image is upgrade to alpine-3.4.

Alpine 3.4 includes Supervisord 3.2 which includes support for sending signals to processes so we can instruct Caddy to reload its configuration instead of doing a full restart (possible from Caddy 0.9).

A new build would also pull Caddy 0.9 for its build on Docker Hub.